### PR TITLE
adjust candy heart for apotheosis crystal chest placement

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -849,6 +849,9 @@ function OnMagicNumbersAndWorldSeedInitialized()
 
 	if ModIsEnabled("Apotheosis") then
 		text = text:gsub([[pos_x="15090"]], [[pos_x="22770"]])
+		text = text:gsub([[pos_x="(-?%d+)"([^>]+candyheart[^>]+>)]], function (num, rest)
+			return string.format([[pos_x="%d"%s]], tonumber(num) - 512, rest)
+		end)
 	end
 	local content = ModTextFileGetContent(biome_path)
 	content = content:gsub("<mBufferedPixelScenes>", text)


### PR DESCRIPTION
apotheosis shifts the crystal chest over a chunk, this stops candy heart floatin out in the clouds 512 px east of the desired location

the regex jank here at least tries to stay on target in case something ever gets the same x coordinate

edit: coral chest** lmao